### PR TITLE
Dockerfile.*: Fix "etcd is distributed" -> "etcd is a distributed"

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -16,5 +16,5 @@ ENTRYPOINT ["/usr/bin/etcd"]
 COPY --from=builder /go/src/go.etcd.io/etcd/bin/etcd /usr/bin/
 
 LABEL io.k8s.display-name="etcd server" \
-      io.k8s.description="etcd is distributed key-value store which stores the persistent master state for Kubernetes and OpenShift." \
+      io.k8s.description="etcd is a distributed key-value store which stores the persistent master state for Kubernetes and OpenShift." \
       maintainer="Sam Batschelet <sbatsche@redhat.com>"

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -16,5 +16,5 @@ ENTRYPOINT ["/usr/bin/etcd"]
 COPY --from=builder /go/src/go.etcd.io/etcd/bin/etcd /usr/bin/
 
 LABEL io.k8s.display-name="etcd server" \
-      io.k8s.description="etcd is distributed key-value store which stores the persistent master state for Kubernetes and OpenShift." \
+      io.k8s.description="etcd is a distributed key-value store which stores the persistent master state for Kubernetes and OpenShift." \
       maintainer="Sam Batschelet <sbatsche@redhat.com>"


### PR DESCRIPTION
Correcting a typo from 2f109647 (version: openshift-v4.0, 2018-11-29).

CC @hexfusion