### PR TITLE
Dockerfile.*: Also copy etcdctl to the target image

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -14,6 +14,7 @@ FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 ENTRYPOINT ["/usr/bin/etcd"]
 
 COPY --from=builder /go/src/go.etcd.io/etcd/bin/etcd /usr/bin/
+COPY --from=builder /go/src/go.etcd.io/etcd/bin/etcdctl /usr/bin/
 
 LABEL io.k8s.display-name="etcd server" \
       io.k8s.description="etcd is distributed key-value store which stores the persistent master state for Kubernetes and OpenShift." \

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -14,6 +14,7 @@ FROM openshift/origin-base
 ENTRYPOINT ["/usr/bin/etcd"]
 
 COPY --from=builder /go/src/go.etcd.io/etcd/bin/etcd /usr/bin/
+COPY --from=builder /go/src/go.etcd.io/etcd/bin/etcdctl /usr/bin/
 
 LABEL io.k8s.display-name="etcd server" \
       io.k8s.description="etcd is distributed key-value store which stores the persistent master state for Kubernetes and OpenShift." \


### PR DESCRIPTION
We're already building it, and the installer wants `etcdctl` to [monitor the etcd cluster health during bootstrapping][1].

CC @hexfusion

[1]: https://github.com/openshift/installer/blob/v0.12.0/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template#L177-L198