### PR TITLE
Dockerfile: add etcdctl

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -13,7 +13,7 @@ FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 
 ENTRYPOINT ["/usr/bin/etcd"]
 
-COPY --from=builder /go/src/go.etcd.io/etcd/bin/etcd /usr/bin/
+COPY --from=builder /go/src/go.etcd.io/etcd/bin/{etcd,etcdctl} /usr/bin/
 
 LABEL io.k8s.display-name="etcd server" \
       io.k8s.description="etcd is distributed key-value store which stores the persistent master state for Kubernetes and OpenShift." \

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -13,7 +13,7 @@ FROM openshift/origin-base
 
 ENTRYPOINT ["/usr/bin/etcd"]
 
-COPY --from=builder /go/src/go.etcd.io/etcd/bin/etcd /usr/bin/
+COPY --from=builder /go/src/go.etcd.io/etcd/bin/{etcd,etcdctl} /usr/bin/
 
 LABEL io.k8s.display-name="etcd server" \
       io.k8s.description="etcd is distributed key-value store which stores the persistent master state for Kubernetes and OpenShift." \


### PR DESCRIPTION
`Dockerfile.openshift` and `Dockerfile.rhel` do not include etcdctl binary in the build this PR resolves that.
