### PR TITLE
Dockerfile: bump golang to 1.11

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
 
 ENV GOPATH /go
 

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM openshift/golang-builder:1.10 AS builder
+FROM openshift/golang-builder:1.11 AS builder
 
 ENV GOPATH /go
 


### PR DESCRIPTION
Bumping docker to 1.11 for 4.2

This was already bumped in release CI. https://github.com/openshift/release/pull/4321