### PR TITLE
BUG 1747124: Dockerfile: use build instead of make build

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -4,7 +4,7 @@ WORKDIR /go/src/github.com/coreos/etcd
 
 COPY . .
 
-RUN make build
+RUN ./build
 
 # stage 2
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -4,7 +4,7 @@ WORKDIR /go/src/github.com/coreos/etcd
 
 COPY . .
 
-RUN make build
+RUN ./build
 
 # stage 2
 FROM openshift/origin-base


### PR DESCRIPTION
`make build` performs a sanity test on the binary image which causes problems for an unsupported arch. Because we run full CI tests against the image this check is not nessisary and will allow images to be build regardless of arch.

/cc @yselkowitz

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>

