### PR TITLE
Dockerfile: bump golang 1.12

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 
 WORKDIR /go/src/github.com/coreos/etcd
 

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM openshift/golang-builder:1.11 AS builder
+FROM openshift/golang-builder:1.12 AS builder
 
 WORKDIR /go/src/github.com/coreos/etcd
 


### PR DESCRIPTION
[1 of 2]

This change is 1 of 2 to bump etcd to golang 1.12 which is required for etcd 3.3.15 which we will ship in 4.3
