### PR TITLE
[wip]: etcdserver: add separate chain of trust for metrics

### DIFF
--- a/Documentation/op-guide/configuration.md
+++ b/Documentation/op-guide/configuration.md
@@ -338,6 +338,41 @@ The security flags help to [build a secure etcd cluster][security].
 + default: ""
 + env variable: ETCD_PEER_CERT_ALLOWED_HOSTNAME
 
+### --metric-cert-file
++ Path to the metric server TLS cert file.
++ default: ""
++ env variable: ETCD_METRIC_CERT_FILE
+
+### --metric-key-file
++ Path to the metric server TLS key file.
++ default: ""
++ env variable: ETCD_METRIC_KEY_FILE
+
+### --metric-cert-auth
++ Enable metric cert authentication.
++ default: false
++ env variable: ETCD_METRIC_CERT_AUTH
+
+### --metric-crl-file
++ Path to the metric certificate revocation list file.
++ default: ""
++ env variable: ETCD_METRIC_CRL_FILE
+
+### --metric-cert-allowed-hostname
++ Allowed TLS name for metric cert authentication.
++ default: ""
++ env variable: ETCD_METRIC_CERT_ALLOWED_HOSTNAME
+
+### --metric-trusted-ca-file
++ Path to the metric server TLS trusted CA cert file.
++ default: ""
++ env variable: ETCD_METRIC_TRUSTED_CA_FILE
+
+### --metric-auto-tls
++ Metric TLS using generated certificates
++ default: false
++ env variable: ETCD_METRIC_AUTO_TLS
+
 ### --cipher-suites
 + Comma-separated list of supported TLS cipher suites between server/client and peers.
 + default: ""

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -212,6 +212,13 @@ func newConfig() *config {
 	fs.StringVar(&cfg.ec.PeerTLSInfo.AllowedHostname, "peer-cert-allowed-hostname", "", "Allowed TLS hostname for inter peer authentication.")
 	fs.Var(flags.NewStringsValue(""), "cipher-suites", "Comma-separated list of supported TLS cipher suites between client/server and peers (empty will be auto-populated by Go).")
 	fs.BoolVar(&cfg.ec.PeerTLSInfo.SkipClientSANVerify, "experimental-peer-skip-client-san-verification", false, "Skip verification of SAN field in client certificate for peer connections.")
+	fs.StringVar(&cfg.ec.MetricTLSInfo.CertFile, "metric-cert-file", "", "Path to the client server TLS cert file.")
+	fs.StringVar(&cfg.ec.MetricTLSInfo.KeyFile, "metric-key-file", "", "Path to the client server TLS key file.")
+	fs.BoolVar(&cfg.ec.MetricTLSInfo.ClientCertAuth, "metric-cert-auth", false, "Enable metric cert authentication.")
+	fs.StringVar(&cfg.ec.MetricTLSInfo.CRLFile, "metric-crl-file", "", "Path to the metric certificate revocation list file.")
+	fs.StringVar(&cfg.ec.MetricTLSInfo.AllowedHostname, "metric-cert-allowed-hostname", "", "Allowed TLS hostname for metric cert authentication.")
+	fs.StringVar(&cfg.ec.MetricTLSInfo.TrustedCAFile, "metric-trusted-ca-file", "", "Path to the metric server TLS trusted CA cert file.")
+	fs.BoolVar(&cfg.ec.MetricAutoTLS, "metric-auto-tls", false, "Client TLS using generated certificates")
 
 	fs.Var(
 		flags.NewUniqueURLsWithExceptions("*", "*"),

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -152,6 +152,20 @@ Security:
     Peer TLS using self-generated certificates if --peer-key-file and --peer-cert-file are not provided.
   --peer-crl-file ''
     Path to the peer certificate revocation list file.
+  --metric-cert-file ''
+    Path to the metric server TLS cert file.
+  --metric-key-file ''
+    Path to the metric server TLS key file.
+  --metric-cert-auth 'false'
+    Enable metric cert authentication.
+  --metric-crl-file ''
+    Path to the metric certificate revocation list file.
+  --metric-cert-allowed-hostname ''
+    Allowed TLS hostname for metric cert authentication.
+  --metric-trusted-ca-file ''
+    Path to the metric server TLS trusted CA cert file.
+  --metric-auto-tls 'false'
+    Metric server TLS using generated certificates.
   --cipher-suites ''
     Comma-separated list of supported TLS cipher suites between client/server and peers (empty will be auto-populated by Go).
   --cors '*'


### PR DESCRIPTION
This adds the basic layout for separating the chain of trust for metrics
Currently only the ` --metric-auto-tls=true` was implemented, the next
steps would be to 

- [x] verify if certs provided from command line args will work
- [x] add tests cases if any required. EDIT: update the functional tests
- [ ] figure out what `metric-cert-allowed-hostname`, `metric-crl-file`
are, implement them if necessary, if not remove them.
- [x] fix help docs