### PR TITLE
Bug 1814576: make evaluation of targetMember strict

### DIFF
--- a/openshift-tools/pkg/discover-etcd-initial-cluster/initial-cluster.go
+++ b/openshift-tools/pkg/discover-etcd-initial-cluster/initial-cluster.go
@@ -239,7 +239,7 @@ func (o *DiscoverEtcdInitialClusterOptions) checkForTarget(client *clientv3.Clie
 	for i := range memberResponse.Members {
 		member := memberResponse.Members[i]
 		for _, peerURL := range member.PeerURLs {
-			if strings.Contains(peerURL, o.TargetPeerURLHost) {
+			if peerURL == ("https://" + o.TargetPeerURLHost + ":2380") {
 				targetMember = member
 			}
 		}


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.

fixes
```
2020-05-14T04:56:02.740379813Z 2789a93832bcda39, started, nuc4.redpill.nz, https://10.1.10.4:2380, https://10.1.10.4:2379
2020-05-14T04:56:02.740379813Z 5187f12b86fd7087, unstarted, , https://10.1.10.3:2380, 
2020-05-14T04:56:02.740379813Z f374a1615f0d67db, started, etcd-bootstrap, https://10.1.10.31:2380, https://10.1.10.31:2379
2020-05-14T04:56:02.743273696Z memberDir /var/lib/etcd/member is present on nuc3.redpill.nz
2020-05-14T04:56:02.750948567Z #### attempt 0
2020-05-14T04:56:02.751779911Z       member={name="nuc4.redpill.nz", peerURLs=[https://10.1.10.4:2380}, clientURLs=[https://10.1.10.4:2379]
2020-05-14T04:56:02.751779911Z       member={name="", peerURLs=[https://10.1.10.3:2380}, clientURLs=[]
2020-05-14T04:56:02.751779911Z       member={name="etcd-bootstrap", peerURLs=[https://10.1.10.31:2380}, clientURLs=[https://10.1.10.31:2379]
2020-05-14T04:56:02.751779911Z       target={name="etcd-bootstrap", peerURLs=[https://10.1.10.31:2380}, clientURLs=[https://10.1.10.31:2379], err=<nil>

```