### PR TITLE
Bug 1883772: discover-etcd-initial-cluster: improve error handling when we dont scale member

### DIFF
--- a/openshift-tools/pkg/discover-etcd-initial-cluster/initial-cluster.go
+++ b/openshift-tools/pkg/discover-etcd-initial-cluster/initial-cluster.go
@@ -244,8 +244,11 @@ func (o *DiscoverEtcdInitialClusterOptions) checkForTarget(client *clientv3.Clie
 			}
 		}
 	}
+	if targetMember == nil {
+		return nil, nil, fmt.Errorf("peer %q not found in member list, check operator logs for possible scaling problems", "https://"+o.TargetPeerURLHost+":2380")
+	}
 
-	return targetMember, memberResponse.Members, err
+	return targetMember, memberResponse.Members, nil
 }
 
 func (o *DiscoverEtcdInitialClusterOptions) getClient() (*clientv3.Client, error) {


### PR DESCRIPTION
`discover-etcd-initial-cluster` will fail without an error if the member has not been added to the cluster before etcd starts.

```
  47c2911fa3f192a1, started, etcd-bootstrap, https://192.168.1.239:2380, https://192.168.1.239:2379, false
  6eac2c0354f41bcb, started, wj45uos929a-4qdsw-master-2, https://192.168.1.29:2380, https://192.168.1.29:2379, false
  8b25c3c3bdeb7654, started, wj45uos929a-4qdsw-master-1, https://192.168.1.11:2380, https://192.168.1.11:2379, false
  #### attempt 0
        member={name="etcd-bootstrap", peerURLs=[https://192.168.1.239:2380}, clientURLs=[https://192.168.1.239:2379]
        member={name="wj45uos929a-4qdsw-master-2", peerURLs=[https://192.168.1.29:2380}, clientURLs=[https://192.168.1.29:2379]
        member={name="wj45uos929a-4qdsw-master-1", peerURLs=[https://192.168.1.11:2380}, clientURLs=[https://192.168.1.11:2379]
        target=nil, err=<nil>
  #### sleeping...
  #### attempt 1
        member={name="etcd-bootstrap", peerURLs=[https://192.168.1.239:2380}, clientURLs=[https://192.168.1.239:2379]
        member={name="wj45uos929a-4qdsw-master-2", peerURLs=[https://192.168.1.29:2380}, clientURLs=[https://192.168.1.29:2379]
        member={name="wj45uos929a-4qdsw-master-1", peerURLs=[https://192.168.1.11:2380}, clientURLs=[https://192.168.1.11:2379]
        target=nil, err=<nil>
  #### sleeping...
  #### attempt 2
        member={name="etcd-bootstrap", peerURLs=[https://192.168.1.239:2380}, clientURLs=[https://192.168.1.239:2379]
        member={name="wj45uos929a-4qdsw-master-2", peerURLs=[https://192.168.1.29:2380}, clientURLs=[https://192.168.1.29:2379]
        member={name="wj45uos929a-4qdsw-master-1", peerURLs=[https://192.168.1.11:2380}, clientURLs=[https://192.168.1.11:2379]
        target=nil, err=<nil>
```
