### PR TITLE
Bug 1878163: Updating ose-etcd builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM openshift/golang-builder:1.12 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.12 AS builder
 
 WORKDIR /go/src/go.etcd.io/etcd
 
@@ -7,7 +7,7 @@ COPY . .
 RUN ./build
 
 # stage 2
-FROM openshift/origin-base
+FROM registry.svc.ci.openshift.org/ocp/4.6:base
 
 ENTRYPOINT ["/usr/bin/etcd"]
 


### PR DESCRIPTION
Updating ose-etcd builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/990044f295fb1d5e238823902962dbcfa1c041c9/images/ose-etcd.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
