### PR TITLE
Updating ose-etcd builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -7,7 +7,7 @@ COPY . .
 RUN ./build
 
 # stage 2
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 
 ENTRYPOINT ["/usr/bin/etcd"]
 


### PR DESCRIPTION
Updating ose-etcd builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/ose-etcd.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.