### PR TITLE
UPSTREAM: <carry>: *: ensure zap logger is set before use

### DIFF
--- a/embed/etcd.go
+++ b/embed/etcd.go
@@ -113,7 +113,7 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		e = nil
 	}()
 
-	if !cfg.SocketOpts.Empty() {
+	if cfg.logger != nil && !cfg.SocketOpts.Empty() {
 		cfg.logger.Info(
 			"configuring socket options",
 			zap.Bool("reuse-address", cfg.SocketOpts.ReuseAddress),


### PR DESCRIPTION
oversight on the backport, zap logger is not yet the default for release-3.4 so it must be checked before use,
