### PR TITLE
Bug 1994986: (CARRY) etcdctl/ctlv3/ctl.go: Remove check perf command

### DIFF
--- a/etcdctl/ctlv3/command/check.go
+++ b/etcdctl/ctlv3/command/check.go
@@ -107,12 +107,9 @@ var checkDatascaleCfgMap = map[string]checkDatascaleCfg{
 // NewCheckCommand returns the cobra command for "check".
 func NewCheckCommand() *cobra.Command {
 	cc := &cobra.Command{
-		Use:   "check <subcommand>",
-		Short: "commands for checking properties of the etcd cluster",
+		Use:   "check <subcommand> is no longer supported in OpenShift. Performance analysis should be performed using metrics, please see the etcd dashboards",
+		Short: "command no longer supported in OpenShift",
 	}
-
-	cc.AddCommand(NewCheckPerfCommand())
-	cc.AddCommand(NewCheckDatascaleCommand())
 
 	return cc
 }


### PR DESCRIPTION
This is often used by both support and end users, which causes
etcd to get load sometimes in live production env.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
