### PR TITLE
[TEST] server/etcdserver/api/membership: TESTING ONLY maxLearner 5

### DIFF
--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -41,7 +41,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const maxLearners = 1
+const maxLearners = 5
 
 // RaftCluster is a list of Members that belong to the same raft cluster
 type RaftCluster struct {


### PR DESCRIPTION
This PR is testing only for validation of using multi-learner instances for cluster bootstrap.

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
