### PR TITLE
Remove MemberList patch

### DIFF
--- a/client/v3/cluster.go
+++ b/client/v3/cluster.go
@@ -124,7 +124,7 @@ func (c *cluster) MemberUpdate(ctx context.Context, id uint64, peerAddrs []strin
 
 func (c *cluster) MemberList(ctx context.Context) (*MemberListResponse, error) {
 	// it is safe to retry on list.
-	resp, err := c.remote.MemberList(ctx, &pb.MemberListRequest{}, c.callOpts...)
+	resp, err := c.remote.MemberList(ctx, &pb.MemberListRequest{Linearizable: true}, c.callOpts...)
 	if err == nil {
 		return (*MemberListResponse)(resp), nil
 	}

--- a/client/v3/patch_cluster.go
+++ b/client/v3/patch_cluster.go
@@ -1,0 +1,24 @@
+package clientv3
+
+import (
+	"context"
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+)
+
+// NonLinearizeableMemberLister is used by the discover-etcd-initial-cluster command to get a list of members to ensure that *this*
+// member has been added to the list.  This is needed on restart scenarios when there isn't quorum.  We need the first
+// two etcd servers to start without quorum having been established by finding themselves in the member list and moving
+// past the gate.
+type NonLinearizeableMemberLister interface {
+	// NonLinearizeableMemberList is like MemberList only without linearization.
+	NonLinearizeableMemberList(ctx context.Context) (*MemberListResponse, error)
+}
+
+func (c *cluster) NonLinearizeableMemberList(ctx context.Context) (*MemberListResponse, error) {
+	// it is safe to retry on list.
+	resp, err := c.remote.MemberList(ctx, &pb.MemberListRequest{}, c.callOpts...)
+	if err == nil {
+		return (*MemberListResponse)(resp), nil
+	}
+	return nil, toErr(ctx, err)
+}

--- a/openshift-tools/pkg/discover-etcd-initial-cluster/initial-cluster.go
+++ b/openshift-tools/pkg/discover-etcd-initial-cluster/initial-cluster.go
@@ -154,7 +154,7 @@ func (o *DiscoverEtcdInitialClusterOptions) Run() error {
 		fmt.Fprintf(os.Stderr, "#### attempt %d\n", i)
 
 		// Check member list on each iteration for changes.
-		cluster, err := client.MemberList(context.TODO())
+		cluster, err := client.Cluster.(clientv3.NonLinearizeableMemberLister).NonLinearizeableMemberList(context.TODO())
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "member list request failed: %v", err)
 			continue


### PR DESCRIPTION
// NonLinearizeableMemberLister is used by the discover-etcd-initial-cluster command to get a list of members to ensure that *this*
// member has been added to the list.  This is needed on restart scenarios when there isn't quorum.  We need the first
// two etcd servers to start without quorum having been established by finding themselves in the member list and moving
// past the gate.

This makes our MemberList match upstream so that all its users get consistent semantics. We still have the non-linearlizeable option for our own bootstrapping.