### PR TITLE
increases cluster discovery time from 10s to 180s

### DIFF
--- a/openshift-tools/pkg/discover-etcd-initial-cluster/initial-cluster.go
+++ b/openshift-tools/pkg/discover-etcd-initial-cluster/initial-cluster.go
@@ -168,7 +168,7 @@ func (o *DiscoverEtcdInitialClusterOptions) Run() error {
 		// If member is not yet part of the cluster print to stderr and retry.
 		if err != nil && !memberFound {
 			fmt.Fprintf(os.Stderr, "      %s\n#### sleeping...\n", err.Error())
-			time.Sleep(1 * time.Second)
+			time.Sleep(18 * time.Second)
 			continue
 		}
 		// Empty string value for initialCluster is valid.


### PR DESCRIPTION
it gives more time to the etcd operator to add a new member.
the etcd operator expects the etcd container to be in a running state.
too tight timeout will cause the container to restart and decreasing operator chances

I think we should also increase pod's `initialDelaySeconds` to match the timeout.
