### PR TITLE
Revert "UPSTREAM: <carry>: increases cluster discovery time from 10s to 180s"

### DIFF
--- a/openshift-tools/pkg/discover-etcd-initial-cluster/initial-cluster.go
+++ b/openshift-tools/pkg/discover-etcd-initial-cluster/initial-cluster.go
@@ -168,7 +168,7 @@ func (o *DiscoverEtcdInitialClusterOptions) Run() error {
 		// If member is not yet part of the cluster print to stderr and retry.
 		if err != nil && !memberFound {
 			fmt.Fprintf(os.Stderr, "      %s\n#### sleeping...\n", err.Error())
-			time.Sleep(18 * time.Second)
+			time.Sleep(1 * time.Second)
 			continue
 		}
 		// Empty string value for initialCluster is valid.


### PR DESCRIPTION


This reverts commit a66d3c31d0f6d7c5cd9cb8740d19e865a95a8e65.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
