### PR TITLE
Bug 2085997: increases cluster discovery time from 10s to 135s

### DIFF
--- a/openshift-tools/pkg/discover-etcd-initial-cluster/initial-cluster.go
+++ b/openshift-tools/pkg/discover-etcd-initial-cluster/initial-cluster.go
@@ -150,7 +150,8 @@ func (o *DiscoverEtcdInitialClusterOptions) Run() error {
 	}
 	defer client.Close()
 
-	for i := 0; i < 10; i++ {
+	// the startupProbe waits for 180s, so we are giving 135s to this process and 45s to the etcd that runs after us.
+	for i := 0; i < 135; i++ {
 		fmt.Fprintf(os.Stderr, "#### attempt %d\n", i)
 
 		// Check member list on each iteration for changes.


### PR DESCRIPTION
it gives more time to the etcd operator to add a new member.
the etcd operator expects the etcd container to be in a running state.
too tight timeout will cause the container to restart and decreasing operator chances


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
