### PR TITLE
Bug OCPBUGS-3098: UPSTREAM: <carry>: server/etcdmain: add configurable cipher list to gRPC proxy listener

### DIFF
--- a/client/pkg/tlsutil/cipher_suites.go
+++ b/client/pkg/tlsutil/cipher_suites.go
@@ -14,7 +14,10 @@
 
 package tlsutil
 
-import "crypto/tls"
+import (
+	"crypto/tls"
+	"fmt"
+)
 
 // GetCipherSuite returns the corresponding cipher suite,
 // and boolean value if it is supported.
@@ -36,4 +39,18 @@ func GetCipherSuite(s string) (uint16, bool) {
 		return tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, true
 	}
 	return 0, false
+}
+
+// GetCipherSuites returns list of corresponding cipher suite IDs.
+func GetCipherSuites(ss []string) ([]uint16, error) {
+	cs := make([]uint16, len(ss))
+	for i, s := range ss {
+		var ok bool
+		cs[i], ok = GetCipherSuite(s)
+		if !ok {
+			return nil, fmt.Errorf("unexpected TLS cipher suite %q", s)
+		}
+	}
+
+	return cs, nil
 }

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -623,13 +623,9 @@ func updateCipherSuites(tls *transport.TLSInfo, ss []string) error {
 		return fmt.Errorf("TLSInfo.CipherSuites is already specified (given %v)", ss)
 	}
 	if len(ss) > 0 {
-		cs := make([]uint16, len(ss))
-		for i, s := range ss {
-			var ok bool
-			cs[i], ok = tlsutil.GetCipherSuite(s)
-			if !ok {
-				return fmt.Errorf("unexpected TLS cipher suite %q", s)
-			}
+		cs, err := tlsutil.GetCipherSuites(ss)
+		if err != nil {
+			return err
 		}
 		tls.CipherSuites = cs
 	}

--- a/tests/e2e/etcd_config_test.go
+++ b/tests/e2e/etcd_config_test.go
@@ -320,6 +320,46 @@ func TestGrpcproxyAndCommonName(t *testing.T) {
 	}
 }
 
+func TestGrpcproxyAndListenCipherSuite(t *testing.T) {
+	e2e.SkipInShortMode(t)
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "ArgsWithCipherSuites",
+			args: []string{
+				e2e.BinDir + "/etcd",
+				"grpc-proxy",
+				"start",
+				"--listen-cipher-suites", "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+			},
+		},
+		{
+			name: "ArgsWithoutCipherSuites",
+			args: []string{
+				e2e.BinDir + "/etcd",
+				"grpc-proxy",
+				"start",
+				"--listen-cipher-suites", "",
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			pw, err := e2e.SpawnCmd(test.args, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err = pw.Stop(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestBootstrapDefragFlag(t *testing.T) {
 	skipInShortMode(t)
 


### PR DESCRIPTION
Carrying upstream fix for https://issues.redhat.com/browse/OCPBUGS-1123
