### PR TITLE
UPSTREAM <carry>: Add range response KV length as a metric

### DIFF
--- a/server/etcdserver/metrics.go
+++ b/server/etcdserver/metrics.go
@@ -175,6 +175,12 @@ var (
 		Buckets: prometheus.ExponentialBuckets(0.0001, 2, 20),
 	},
 		[]string{"version", "op", "success"})
+	rangeResponseKvCount = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "etcd",
+		Subsystem: "server",
+		Name:      "range_response_kv_count",
+		Help:      "The number of KVs returned by range calls.",
+	}, []string{"range_begin"})
 )
 
 func init() {
@@ -201,6 +207,7 @@ func init() {
 	prometheus.MustRegister(fdUsed)
 	prometheus.MustRegister(fdLimit)
 	prometheus.MustRegister(applySec)
+	prometheus.MustRegister(rangeResponseKvCount)
 
 	currentVersion.With(prometheus.Labels{
 		"server_version": version.Version,

--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -113,6 +113,11 @@ func (s *EtcdServer) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeRe
 				traceutil.Field{Key: "response_count", Value: len(resp.Kvs)},
 				traceutil.Field{Key: "response_revision", Value: resp.Header.Revision},
 			)
+
+			// collect the metric on very large responses only, because the key dimensionality might blow up Prometheus.
+			if rangeResponseKvCount != nil && len(resp.Kvs) > 1000 {
+				rangeResponseKvCount.WithLabelValues(string(r.Key)).Observe(float64(len(resp.Kvs)))
+			}
 		}
 		trace.LogIfLong(traceThreshold)
 	}(time.Now())


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
