### PR TITLE
CORS-3191: Add Dockerfile to build etcd for openshift-installer

### DIFF
--- a/Dockerfile.installer
+++ b/Dockerfile.installer
@@ -1,0 +1,33 @@
+# This Dockerfile builds an image containing Mac and Linux ARM64/AMD64 versions of the etcd.
+# The resulting image is used to build the openshift-installer binary.
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-etcd-golang-1.19 AS macbuilder
+WORKDIR /go/src/go.etcd.io/etcd
+COPY . .
+RUN GOOS=darwin GOARCH=amd64 GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-etcd-golang-1.19 AS macarmbuilder
+WORKDIR /go/src/go.etcd.io/etcd
+COPY . .
+RUN GOOS=darwin GOARCH=arm64 GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-etcd-golang-1.19 AS linuxbuilder
+WORKDIR /go/src/go.etcd.io/etcd
+COPY . .
+RUN GOOS=linux GOARCH=amd64 GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-etcd-golang-1.19 AS linuxarmbuilder
+WORKDIR /go/src/go.etcd.io/etcd
+COPY . .
+RUN GOOS=linux GOARCH=arm64 GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
+
+# stage 2
+FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
+
+COPY --from=macbuilder /go/src/go.etcd.io/etcd/bin/etcd /usr/share/openshift/darwin/amd64/etcd
+COPY --from=macarmbuilder /go/src/go.etcd.io/etcd/bin/etcd /usr/share/openshift/darwin/arm64/etcd
+COPY --from=linuxbuilder /go/src/go.etcd.io/etcd/bin/etcd /usr/share/openshift/linux/amd64/etcd
+COPY --from=linuxarmbuilder /go/src/go.etcd.io/etcd/bin/etcd /usr/share/openshift/linux/arm64/etcd
+
+# This image is not an operator, it is only used as part of the build pipeline
+LABEL io.openshift.release.operator=false


### PR DESCRIPTION
The installer team are currently migrating towards using Cluster API and envtest to run a temporary control plane as part of the installation procedure.
As part of this requirement, we need to include within the installer etcd binaries, suitable for the 4 architectures supported by the installer program (plus the specific arch for s390x/ppcle64 where appropriate, these are handled separately though).

To ensure that the installer can always support darwin/amd64, darwin/arm64, linux/amd64, linux/arm64, we need to have an intermediary image, built into the CI and ART pipelines, that the installer can source from.

This PR adds a dockerfile that will cross compile the 4 required architectures for etcd and then publish them into an image, I'm intending to call installer-etcd-artifacts.

The same was done for kube-apiserver as well to satisfy that dependency (https://github.com/openshift/kubernetes/pull/1872).
