### PR TITLE
ETCD-537: bump build root go1.20

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.19-openshift-4.13
+  tag: rhel-9-release-golang-1.20-openshift-4.13


### PR DESCRIPTION
This PR bumps build root go-version to g1.20. 

Prepare for https://github.com/openshift/etcd/pull/245, since etcd v3.5.12 use go1.20 

