### PR TITLE
ETCD-537: Revert "bump build root go1.20"

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.20-openshift-4.13
+  tag: rhel-9-release-golang-1.19-openshift-4.13


### PR DESCRIPTION
This reverts commit 6d8f5d2ac3c1a31ad3ac56ae15717ef9856fe076.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
