### PR TITLE
CORS-3249: DOWNSTREAM <carry>: installer: make etcd binaries static

### DIFF
--- a/Dockerfile.installer
+++ b/Dockerfile.installer
@@ -1,25 +1,29 @@
 # This Dockerfile builds an image containing Mac and Linux ARM64/AMD64 versions of the etcd.
-# The resulting image is used to build the openshift-installer binary.
+# The resulting image is used to build the statically-linked openshift-installer binary.
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.16 AS macbuilder
+ENV GO_COMPLIANCE_EXCLUDE=".*"
 WORKDIR /go/src/go.etcd.io/etcd
 COPY . .
-RUN GOOS=darwin GOARCH=amd64 GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
+RUN CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.16 AS macarmbuilder
+ENV GO_COMPLIANCE_EXCLUDE=".*"
 WORKDIR /go/src/go.etcd.io/etcd
 COPY . .
-RUN GOOS=darwin GOARCH=arm64 GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
+RUN CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.16 AS linuxbuilder
+ENV GO_COMPLIANCE_EXCLUDE=".*"
 WORKDIR /go/src/go.etcd.io/etcd
 COPY . .
-RUN GOOS=linux GOARCH=amd64 GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.16 AS linuxarmbuilder
+ENV GO_COMPLIANCE_EXCLUDE=".*"
 WORKDIR /go/src/go.etcd.io/etcd
 COPY . .
-RUN GOOS=linux GOARCH=arm64 GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
 
 # stage 2
 FROM registry.ci.openshift.org/ocp/4.16:base-rhel9


### PR DESCRIPTION
The main installer binary is now statically linked and there is a separate binary which is dynamically-linked for fips support (baremetal-installer/openshift-install-fips).

We want the etcd-artifacts image to contain statically-linked binaries to be included in the non-fips openshift-install binary. When building with fips support, we'll get etcd binaries from the regular etcd container image, which has dynamically-linked binaries.

When setting GOOS=X and GOARCH=Y, most of the cross-builds will result in statically linked binaries, except when the host matches X/Y system/arch. So let's be explicit and set `CGO_ENABLED=0` and the exception env var `GO_COMPLIANCE_EXCLUDE`.
