### PR TITLE
DOWNSTREAM: <carry>: ETCD-653: add jq to the etcd image

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -14,6 +14,8 @@ FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 
 ENTRYPOINT ["/usr/bin/etcd"]
 
+RUN yum install --setopt=tsflags=nodocs -y jq && yum clean all && rm -rf /var/cache/yum/*
+
 COPY --from=builder /go/src/go.etcd.io/etcd/bin/etcd /usr/bin/
 COPY --from=builder /go/src/go.etcd.io/etcd/bin/etcdctl /usr/bin/
 COPY --from=builder /go/src/go.etcd.io/etcd/bin/etcdutl /usr/bin/

--- a/Dockerfile.installer
+++ b/Dockerfile.installer
@@ -36,6 +36,8 @@ RUN mkdir -p /usr/share/openshift/$(go env GOOS)/$(go env GOHOSTARCH) && \
 # stage 2
 FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 
+RUN yum install --setopt=tsflags=nodocs -y jq && yum clean all && rm -rf /var/cache/yum/*
+
 COPY --from=macbuilder /go/src/go.etcd.io/etcd/bin/etcd /usr/share/openshift/darwin/amd64/etcd
 COPY --from=macarmbuilder /go/src/go.etcd.io/etcd/bin/etcd /usr/share/openshift/darwin/arm64/etcd
 COPY --from=linuxbuilder /go/src/go.etcd.io/etcd/bin/etcd /usr/share/openshift/linux/amd64/etcd

--- a/Dockerfile.installer.art
+++ b/Dockerfile.installer.art
@@ -75,6 +75,8 @@ RUN mkdir -p /usr/share/openshift/$(go env GOOS)/$(go env GOHOSTARCH) && \
 # stage 2
 FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 
+RUN yum install --setopt=tsflags=nodocs -y jq && yum clean all && rm -rf /var/cache/yum/*
+
 COPY --from=macbuilder /go/src/go.etcd.io/etcd/bin/etcd /usr/share/openshift/darwin/amd64/etcd
 COPY --from=macarmbuilder /go/src/go.etcd.io/etcd/bin/etcd /usr/share/openshift/darwin/arm64/etcd
 COPY --from=linuxbuilder /go/src/go.etcd.io/etcd/bin/etcd /usr/share/openshift/linux/amd64/etcd

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -12,6 +12,8 @@ FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 
 ENTRYPOINT ["/usr/bin/etcd"]
 
+RUN yum install --setopt=tsflags=nodocs -y jq && yum clean all && rm -rf /var/cache/yum/*
+
 COPY --from=builder /go/src/go.etcd.io/etcd/bin/etcd /usr/bin/
 COPY --from=builder /go/src/go.etcd.io/etcd/bin/etcdctl /usr/bin/
 COPY --from=builder /go/src/go.etcd.io/etcd/bin/etcdutl /usr/bin/


### PR DESCRIPTION
cluster-restore needs to calculate and parse json files, thus adding jq into the release image for etcd now.
