### PR TITLE
ETCD-656: Automate datadir move after quorum-restore

### DIFF
--- a/openshift-tools/pkg/discover-etcd-initial-cluster/initial-cluster_test.go
+++ b/openshift-tools/pkg/discover-etcd-initial-cluster/initial-cluster_test.go
@@ -16,12 +16,13 @@ var (
 
 func Test_ensureValidMember(t *testing.T) {
 	tests := map[string]struct {
-		member             *etcdserverpb.Member
-		dataDirExists      bool
-		wantMemberFound    bool
-		wantInitialCluster string
-		wantErr            bool
-		wantErrString      string
+		member               *etcdserverpb.Member
+		dataDirExists        bool
+		wantMemberFound      bool
+		mismatchingClusterId bool
+		wantInitialCluster   string
+		wantErr              bool
+		wantErrString        string
 	}{
 		"started member found no dataDir": {
 			member:             startedEtcdMember,
@@ -45,6 +46,14 @@ func Test_ensureValidMember(t *testing.T) {
 			wantInitialCluster: emptyInitialCluster,
 			wantErr:            true,
 			wantErrString:      "check operator logs for possible scaling problems",
+		},
+		"member not found with dataDir and mismatching clusterid": {
+			member:               notFoundEtcdMember,
+			wantMemberFound:      true,
+			mismatchingClusterId: true,
+			dataDirExists:        true,
+			wantInitialCluster:   "",
+			wantErr:              false,
 		},
 		"member not found no dataDir": {
 			member:             notFoundEtcdMember,
@@ -79,7 +88,7 @@ func Test_ensureValidMember(t *testing.T) {
 				TargetName:          "etcd-0",
 				DataDir:             "/tmp",
 			}
-			gotInitialCluster, gotMemberFound, err := o.getInitialCluster([]*etcdserverpb.Member{test.member}, test.dataDirExists)
+			gotInitialCluster, gotMemberFound, err := o.getInitialCluster([]*etcdserverpb.Member{test.member}, test.dataDirExists, test.mismatchingClusterId)
 			if gotInitialCluster != test.wantInitialCluster {
 				t.Fatalf("initialCluster: want: %q, got: %q", test.wantInitialCluster, gotInitialCluster)
 			}

--- a/openshift-tools/pkg/discover-etcd-initial-cluster/walutil.go
+++ b/openshift-tools/pkg/discover-etcd-initial-cluster/walutil.go
@@ -1,0 +1,58 @@
+package discover_etcd_initial_cluster
+
+import (
+	"errors"
+	"go.etcd.io/etcd/server/v3/datadir"
+	"go.etcd.io/etcd/server/v3/etcdserver/api/snap"
+	"path/filepath"
+
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/client/pkg/v3/types"
+	"go.etcd.io/etcd/pkg/v3/pbutil"
+	"go.etcd.io/etcd/server/v3/wal"
+	"go.etcd.io/etcd/server/v3/wal/walpb"
+
+	"go.uber.org/zap"
+)
+
+func readClusterIdFromWAL(lg *zap.Logger, dataDir string) (cid types.ID, err error) {
+	walDir := datadir.ToWalDir(dataDir)
+	snapDir := filepath.Join(datadir.ToMemberDir(dataDir), "snap")
+
+	// Find a snapshot to start/restart a raft node
+	ss := snap.New(lg, snapDir)
+
+	var walSnaps []walpb.Snapshot
+	walSnaps, err = wal.ValidSnapshotEntries(lg, walDir)
+	if err != nil {
+		return 0, err
+	}
+
+	snapshot, err := ss.LoadNewestAvailable(walSnaps)
+	if err != nil && !errors.Is(err, snap.ErrNoSnapshot) {
+		return 0, err
+	}
+
+	var walSnap walpb.Snapshot
+	if snapshot != nil {
+		walSnap.Index, walSnap.Term = snapshot.Metadata.Index, snapshot.Metadata.Term
+	}
+
+	w, err := wal.Open(lg, walDir, walSnap)
+	if err != nil {
+		return 0, err
+	}
+
+	defer func() {
+		err = errors.Join(err, w.Close())
+	}()
+
+	walMeta, _, _, err := w.ReadAll()
+	if err != nil {
+		return 0, err
+	}
+
+	var metadata pb.Metadata
+	pbutil.MustUnmarshal(&metadata, walMeta)
+	return types.ID(metadata.ClusterID), nil
+}

--- a/tools/mod/go.sum
+++ b/tools/mod/go.sum
@@ -138,6 +138,7 @@ github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:W
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1 h1:ZFgWrT+bLgsYPirOnRfKLYJLvssAegOj/hgyMFdJZe0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
+github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -409,6 +410,7 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0 h1:UhZDfRO8JRQru4/+LlLE0BRKGF8L+PICnvYZmx/fEGA=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
This PR will add the notion of cluster ID into the initial cluster discovery process. This allows us to automatically archive a data directory when we detect the cluster identifier changing. The cluster identifier will only change when we are running a restore operation.
