### PR TITLE
NO-JIRA: use golang 1.22 image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.21-openshift-4.16
+  tag: rhel-9-release-golang-1.22-openshift-4.17

--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
 WORKDIR $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app
@@ -10,7 +10,7 @@ RUN mkdir -p /go/src/go.etcd.io/
 RUN ln -s $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app /go/src/go.etcd.io/etcd
 
 # stage 2 (note: any changes should reflect in Dockerfile.rhel)
-FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 
 ENTRYPOINT ["/usr/bin/etcd"]
 

--- a/Dockerfile.installer
+++ b/Dockerfile.installer
@@ -1,31 +1,31 @@
 # This Dockerfile builds an image containing Mac and Linux ARM64/AMD64 versions of the etcd.
 # The resulting image is used to build the statically-linked openshift-installer binary.
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS macbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS macbuilder
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 WORKDIR /go/src/go.etcd.io/etcd
 COPY . .
 RUN CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS macarmbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS macarmbuilder
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 WORKDIR /go/src/go.etcd.io/etcd
 COPY . .
 RUN CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS linuxbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS linuxbuilder
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 WORKDIR /go/src/go.etcd.io/etcd
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS linuxarmbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS linuxarmbuilder
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 WORKDIR /go/src/go.etcd.io/etcd
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 WORKDIR /go/src/go.etcd.io/etcd
 COPY . .
@@ -34,7 +34,7 @@ RUN mkdir -p /usr/share/openshift/$(go env GOOS)/$(go env GOHOSTARCH) && \
 	mv bin/etcd /usr/share/openshift/$(go env GOOS)/$(go env GOHOSTARCH)/
 
 # stage 2
-FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 
 COPY --from=macbuilder /go/src/go.etcd.io/etcd/bin/etcd /usr/share/openshift/darwin/amd64/etcd
 COPY --from=macarmbuilder /go/src/go.etcd.io/etcd/bin/etcd /usr/share/openshift/darwin/arm64/etcd

--- a/Dockerfile.installer.art
+++ b/Dockerfile.installer.art
@@ -1,7 +1,7 @@
 # This Dockerfile builds an image containing Mac and Linux ARM64/AMD64 versions of the etcd.
 # The resulting image is used to build the statically-linked openshift-installer binary.
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS macbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS macbuilder
 
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
@@ -15,7 +15,7 @@ RUN source $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/cachito.env \
 	&& export GOFLAGS='-mod=readonly' && export GO_BUILD_FLAGS='-v' \
 	&& CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 ./build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS macarmbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS macarmbuilder
 
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
@@ -29,7 +29,7 @@ RUN source $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/cachito.env \
 	&& export GOFLAGS='-mod=readonly' && export GO_BUILD_FLAGS='-v' \
 	&& CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 ./build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS linuxbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS linuxbuilder
 
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
@@ -43,7 +43,7 @@ RUN source $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/cachito.env \
 	&& export GOFLAGS='-mod=readonly' && export GO_BUILD_FLAGS='-v' \
 	&& CGO_ENABLED=0 GOOS=linux GOARCH=amd64 ./build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS linuxarmbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS linuxarmbuilder
 
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
@@ -57,7 +57,7 @@ RUN source $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/cachito.env \
 	&& export GOFLAGS='-mod=readonly' && export GO_BUILD_FLAGS='-v' \
 	&& CGO_ENABLED=0 GOOS=linux GOARCH=arm64 ./build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
 WORKDIR $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app
@@ -73,7 +73,7 @@ RUN mkdir -p /usr/share/openshift/$(go env GOOS)/$(go env GOHOSTARCH) && \
 	mv bin/etcd /usr/share/openshift/$(go env GOOS)/$(go env GOHOSTARCH)/
 
 # stage 2
-FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 
 COPY --from=macbuilder /go/src/go.etcd.io/etcd/bin/etcd /usr/share/openshift/darwin/amd64/etcd
 COPY --from=macarmbuilder /go/src/go.etcd.io/etcd/bin/etcd /usr/share/openshift/darwin/arm64/etcd

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 
 WORKDIR /go/src/go.etcd.io/etcd
 
@@ -8,7 +8,7 @@ COPY . .
 RUN GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
 
 # stage 2 (note: any changes should reflect in Dockerfile.art)
-FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 
 ENTRYPOINT ["/usr/bin/etcd"]
 


### PR DESCRIPTION
This PR update OCP/Etcd build image to use go1.22

cc @openshift/openshift-team-etcd