### PR TITLE
NO-JIRA: use golang 1.21 image

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
 WORKDIR $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app

--- a/Dockerfile.installer
+++ b/Dockerfile.installer
@@ -1,31 +1,31 @@
 # This Dockerfile builds an image containing Mac and Linux ARM64/AMD64 versions of the etcd.
 # The resulting image is used to build the statically-linked openshift-installer binary.
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.16 AS macbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS macbuilder
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 WORKDIR /go/src/go.etcd.io/etcd
 COPY . .
 RUN CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.16 AS macarmbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS macarmbuilder
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 WORKDIR /go/src/go.etcd.io/etcd
 COPY . .
 RUN CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.16 AS linuxbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS linuxbuilder
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 WORKDIR /go/src/go.etcd.io/etcd
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.16 AS linuxarmbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS linuxarmbuilder
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 WORKDIR /go/src/go.etcd.io/etcd
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 WORKDIR /go/src/go.etcd.io/etcd
 COPY . .

--- a/Dockerfile.installer.art
+++ b/Dockerfile.installer.art
@@ -1,7 +1,7 @@
 # This Dockerfile builds an image containing Mac and Linux ARM64/AMD64 versions of the etcd.
 # The resulting image is used to build the statically-linked openshift-installer binary.
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.16 AS macbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS macbuilder
 
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
@@ -15,7 +15,7 @@ RUN source $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/cachito.env \
 	&& export GOFLAGS='-mod=readonly' && export GO_BUILD_FLAGS='-v' \
 	&& CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 ./build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.16 AS macarmbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS macarmbuilder
 
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
@@ -29,7 +29,7 @@ RUN source $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/cachito.env \
 	&& export GOFLAGS='-mod=readonly' && export GO_BUILD_FLAGS='-v' \
 	&& CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 ./build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.16 AS linuxbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS linuxbuilder
 
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
@@ -43,7 +43,7 @@ RUN source $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/cachito.env \
 	&& export GOFLAGS='-mod=readonly' && export GO_BUILD_FLAGS='-v' \
 	&& CGO_ENABLED=0 GOOS=linux GOARCH=amd64 ./build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.16 AS linuxarmbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS linuxarmbuilder
 
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
@@ -57,7 +57,7 @@ RUN source $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/cachito.env \
 	&& export GOFLAGS='-mod=readonly' && export GO_BUILD_FLAGS='-v' \
 	&& CGO_ENABLED=0 GOOS=linux GOARCH=arm64 ./build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 ENV GO_COMPLIANCE_EXCLUDE=".*"
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
 WORKDIR $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 
 WORKDIR /go/src/go.etcd.io/etcd
 


### PR DESCRIPTION
This PR update OCP/Etcd build image to use go1.21

cc @openshift/openshift-team-etcd