### PR TITLE
NO-ISSUE: Add support for cachi2 based deps

### DIFF
--- a/Dockerfile.installer.art-cachi2
+++ b/Dockerfile.installer.art-cachi2
@@ -1,0 +1,65 @@
+# This Dockerfile builds an image containing Mac and Linux ARM64/AMD64 versions of the etcd.
+# The resulting image is used to build the statically-linked openshift-installer binary.
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS macbuilder
+
+ENV GO_COMPLIANCE_EXCLUDE=".*"
+
+WORKDIR /go/src/go.etcd.io/etcd
+COPY . .
+
+RUN find $GOPATH
+RUN export GOFLAGS='-mod=readonly' && export GO_BUILD_FLAGS='-v' \
+	&& CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 ./build.sh
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS macarmbuilder
+
+ENV GO_COMPLIANCE_EXCLUDE=".*"
+
+WORKDIR /go/src/go.etcd.io/etcd
+COPY . .
+
+RUN export GOFLAGS='-mod=readonly' && export GO_BUILD_FLAGS='-v' \
+	&& CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 ./build.sh
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS linuxbuilder
+
+ENV GO_COMPLIANCE_EXCLUDE=".*"
+
+WORKDIR /go/src/go.etcd.io/etcd
+COPY . .
+RUN export GOFLAGS='-mod=readonly' && export GO_BUILD_FLAGS='-v' \
+	&& CGO_ENABLED=0 GOOS=linux GOARCH=amd64 ./build.sh
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS linuxarmbuilder
+
+ENV GO_COMPLIANCE_EXCLUDE=".*"
+
+WORKDIR /go/src/go.etcd.io/etcd
+COPY . .
+RUN export GOFLAGS='-mod=readonly' && export GO_BUILD_FLAGS='-v' \
+	&& CGO_ENABLED=0 GOOS=linux GOARCH=arm64 ./build.sh
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
+ENV GO_COMPLIANCE_EXCLUDE=".*"
+
+WORKDIR /go/src/go.etcd.io/etcd
+COPY . .
+RUN export GOFLAGS='-mod=readonly' && export GO_BUILD_FLAGS='-v' \
+	&& CGO_ENABLED=0 ./build.sh
+RUN mkdir -p /usr/share/openshift/$(go env GOOS)/$(go env GOHOSTARCH) && \
+	mv bin/etcd /usr/share/openshift/$(go env GOOS)/$(go env GOHOSTARCH)/
+
+# stage 2
+FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
+
+RUN yum install --setopt=tsflags=nodocs -y jq && yum clean all && rm -rf /var/cache/yum/*
+
+COPY --from=macbuilder /go/src/go.etcd.io/etcd/bin/etcd /usr/share/openshift/darwin/amd64/etcd
+COPY --from=macarmbuilder /go/src/go.etcd.io/etcd/bin/etcd /usr/share/openshift/darwin/arm64/etcd
+COPY --from=linuxbuilder /go/src/go.etcd.io/etcd/bin/etcd /usr/share/openshift/linux/amd64/etcd
+COPY --from=linuxarmbuilder /go/src/go.etcd.io/etcd/bin/etcd /usr/share/openshift/linux/arm64/etcd
+COPY --from=builder /usr/share/openshift/ /usr/share/openshift/
+
+# This image is not an operator, it is only used as part of the build pipeline
+LABEL io.openshift.release.operator=false

--- a/go.mod
+++ b/go.mod
@@ -95,4 +95,9 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
+	go.etcd.io/gofail v0.2.0 // indirect
+	github.com/urfave/cli v1.22.4 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 //indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 //indirect
 )


### PR DESCRIPTION
Konflux is replacing RH's internal build system OSBS. OSBS supported a build-time dependency injection system called "cachito". Konflux replaces this with "cachi2" which works differently. REMOTE_SOURCES no longer need to be copied into place and there is no need to source cachito's environment information (Konflux automatically rewrites the Dockerfile to source cachi2/cachi2.env before running the original RUN commands).
Additionally, cachito appears to have provided go.sum dependencies whereas cachi2 requires all build-time dependencies in go.mod. Missing dependencies are added to go.mod as // indirect in this change.
