### PR TITLE
NO-ISSUE: Add support for cachi2 based deps in Dockerfile.art

### DIFF
--- a/Dockerfile.art-cachi2
+++ b/Dockerfile.art-cachi2
@@ -1,0 +1,21 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
+
+WORKDIR /go/src/go.etcd.io/etcd
+COPY . .
+RUN GOFLAGS='-mod=readonly' GO_BUILD_FLAGS='-v' ./build.sh
+
+# stage 2 (note: any changes should reflect in Dockerfile.rhel)
+FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
+
+ENTRYPOINT ["/usr/bin/etcd"]
+
+RUN yum install --setopt=tsflags=nodocs -y jq && yum clean all && rm -rf /var/cache/yum/*
+
+COPY --from=builder /go/src/go.etcd.io/etcd/bin/etcd /usr/bin/
+COPY --from=builder /go/src/go.etcd.io/etcd/bin/etcdctl /usr/bin/
+COPY --from=builder /go/src/go.etcd.io/etcd/bin/etcdutl /usr/bin/
+COPY --from=builder /go/src/go.etcd.io/etcd/bin/discover-etcd-initial-cluster /usr/bin/
+
+LABEL io.k8s.display-name="etcd server" \
+      io.k8s.description="etcd is a distributed key-value store which stores the persistent master state for Kubernetes and OpenShift." \
+      maintainer="Sam Batschelet <sbatsche@redhat.com>"


### PR DESCRIPTION
See https://github.com/openshift/etcd/pull/294 for Dockerfile.installer.art migration.

Konflux is replacing RH's internal build system OSBS. OSBS supported a build-time dependency injection system called "cachito". Konflux replaces this with "cachi2" which works differently. REMOTE_SOURCES no longer need to be copied into place and there is no need to source cachito's environment information (Konflux automatically rewrites the Dockerfile to source cachi2/cachi2.env before running the original RUN commands).
Additionally, cachito appears to have provided go.sum dependencies whereas cachi2 requires all build-time dependencies in go.mod. Missing dependencies are added to go.mod as // indirect in this change.
