### PR TITLE
grpc-proxy: add listen-tls-min-version flag

### DIFF
--- a/server/etcdmain/grpc_proxy.go
+++ b/server/etcdmain/grpc_proxy.go
@@ -78,13 +78,14 @@ var (
 
 	// tls for clients connecting to proxy
 
-	grpcProxyListenCA           string
-	grpcProxyListenCert         string
-	grpcProxyListenKey          string
-	grpcProxyListenCipherSuites []string
-	grpcProxyListenAutoTLS      bool
-	grpcProxyListenCRL          string
-	selfSignedCertValidity      uint
+	grpcProxyListenCA            string
+	grpcProxyListenCert          string
+	grpcProxyListenKey           string
+	grpcProxyListenCipherSuites  []string
+	grpcProxyListenTLSMinVersion string
+	grpcProxyListenAutoTLS       bool
+	grpcProxyListenCRL           string
+	selfSignedCertValidity       uint
 
 	grpcProxyAdvertiseClientURL string
 	grpcProxyResolverPrefix     string
@@ -163,6 +164,7 @@ func newGRPCProxyStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&grpcProxyListenKey, "key-file", "", "identify secure connections to the proxy using this TLS key file")
 	cmd.Flags().StringVar(&grpcProxyListenCA, "trusted-ca-file", "", "verify certificates of TLS-enabled secure proxy using this CA bundle")
 	cmd.Flags().StringSliceVar(&grpcProxyListenCipherSuites, "listen-cipher-suites", grpcProxyListenCipherSuites, "Comma-separated list of supported TLS cipher suites between client/proxy (empty will be auto-populated by Go).")
+	cmd.Flags().StringVar(&grpcProxyListenTLSMinVersion, "listen-tls-min-version", grpcProxyListenTLSMinVersion, "Minimum TLS version supported between client/proxy. Possible values: TLS1.2, TLS1.3.")
 	cmd.Flags().BoolVar(&grpcProxyListenAutoTLS, "auto-tls", false, "proxy TLS using generated certificates")
 	cmd.Flags().StringVar(&grpcProxyListenCRL, "client-crl-file", "", "proxy client certificate revocation list file.")
 	cmd.Flags().UintVar(&selfSignedCertValidity, "self-signed-cert-validity", 1, "The validity period of the proxy certificates, unit is year")
@@ -215,6 +217,19 @@ func startGRPCProxy(cmd *cobra.Command, args []string) {
 			tlsInfo = &transport.TLSInfo{}
 		}
 		tlsInfo.CipherSuites = cs
+	}
+	if len(grpcProxyListenTLSMinVersion) > 0 {
+		var tlsMinVersion uint16
+		switch grpcProxyListenTLSMinVersion {
+		case "TLS1.3":
+			tlsMinVersion = tls.VersionTLS13
+		case "TLS1.2":
+			tlsMinVersion = tls.VersionTLS12
+		}
+		if tlsInfo == nil {
+			tlsInfo = &transport.TLSInfo{}
+		}
+		tlsInfo.MinVersion = tlsMinVersion
 	}
 
 	if tlsInfo != nil {
@@ -291,6 +306,12 @@ func checkArgs() {
 	}
 	if grpcProxyListenAutoTLS && selfSignedCertValidity == 0 {
 		fmt.Fprintln(os.Stderr, fmt.Errorf("selfSignedCertValidity is invalid,it should be greater than 0"))
+		os.Exit(1)
+	}
+	switch grpcProxyListenTLSMinVersion {
+	case "TLS1.2", "TLS1.3", "":
+	default:
+		fmt.Fprintln(os.Stderr, fmt.Errorf("invalid listen-tls-min-version %q", grpcProxyListenTLSMinVersion))
 		os.Exit(1)
 	}
 }

--- a/server/etcdmain/grpc_proxy.go
+++ b/server/etcdmain/grpc_proxy.go
@@ -197,13 +197,6 @@ func startGRPCProxy(cmd *cobra.Command, args []string) {
 	// The empty CN is required for grpcProxyCert.
 	// Please see https://github.com/etcd-io/etcd/issues/11970#issuecomment-687875315  for more context.
 	tlsInfo := newTLS(grpcProxyListenCA, grpcProxyListenCert, grpcProxyListenKey, false)
-	if len(grpcProxyListenCipherSuites) > 0 {
-		cs, err := tlsutil.GetCipherSuites(grpcProxyListenCipherSuites)
-		if err != nil {
-			log.Fatal(err)
-		}
-		tlsInfo.CipherSuites = cs
-	}
 	if tlsInfo == nil && grpcProxyListenAutoTLS {
 		host := []string{"https://" + grpcProxyListenAddr}
 		dir := filepath.Join(grpcProxyDataDir, "fixtures", "proxy")
@@ -212,6 +205,16 @@ func startGRPCProxy(cmd *cobra.Command, args []string) {
 			log.Fatal(err)
 		}
 		tlsInfo = &autoTLS
+	}
+	if len(grpcProxyListenCipherSuites) > 0 {
+		cs, err := tlsutil.GetCipherSuites(grpcProxyListenCipherSuites)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if tlsInfo == nil {
+			tlsInfo = &transport.TLSInfo{}
+		}
+		tlsInfo.CipherSuites = cs
 	}
 
 	if tlsInfo != nil {


### PR DESCRIPTION
grpc-proxy cannot start when specifying **only** `TLS1.3` cipher suites (using the `--listen-cipher-suites` flag) without being able to set the minimum TLS version, results in an error since the default min TLS version for go is `TLS1.2`. When min TLS version is when using `TLS1.2` (the go default), http/2 requires the `AES_128_GCM_SHA256` cipher, which it not available in the `TLS1.3` cipher suites.

- **etcd-proxy: prevent panic on nil tlsInfo**
- **grpc-proxy: add listen-tls-min-version flag**
