### PR TITLE
OCPBUGS-50510: Add configurable option for hardware-related timeout delay

### DIFF
--- a/server/wal/wal.go
+++ b/server/wal/wal.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -92,6 +93,8 @@ type WAL struct {
 
 	locks []*fileutil.LockedFile // the locked files the WAL holds (the name is increasing)
 	fp    *filePipeline
+
+	openshiftWarnFsyncDuration *time.Duration
 }
 
 // Create creates a WAL ready for appending records. The given metadata is
@@ -797,11 +800,25 @@ func (w *WAL) sync() error {
 		return nil
 	}
 
+	if w.openshiftWarnFsyncDuration == nil {
+		defaultWarnFsyncDuration := warnSyncDuration
+		w.openshiftWarnFsyncDuration = &defaultWarnFsyncDuration
+		if warnFsyncDurationOverride := os.Getenv("OPENSHIFT_WARN_FSYNC_DURATION"); warnFsyncDurationOverride != "" {
+			override, err := strconv.Atoi(warnFsyncDurationOverride)
+			if err != nil {
+				w.lg.Sugar().Infof("OPENSHIFT_WARN_FSYNC_DURATION specified but could not be parsed. falling back to default of %v. parse error: %v", warnSyncDuration, err)
+			} else {
+				openshiftWarnFsyncDuration := time.Duration(override) * time.Second
+				w.openshiftWarnFsyncDuration = &openshiftWarnFsyncDuration
+			}
+		}
+	}
+
 	start := time.Now()
 	err := fileutil.Fdatasync(w.tail().File)
 
 	took := time.Since(start)
-	if took > warnSyncDuration {
+	if took > *w.openshiftWarnFsyncDuration {
 		w.lg.Warn(
 			"slow fdatasync",
 			zap.Duration("took", took),


### PR DESCRIPTION
defaults to 25 seconds to get us closer to the request timeout that is used in the kube-apiserver of 34 seconds.
configuration option to override default with `OPENSHIFT_ETCD_HARDWARE_DELAY_TIMEOUT` environment variable