### PR TITLE
OCPBUGS-52181: Ensure cluster id changes during force-new-cluster

### DIFF
--- a/server/etcdserver/api/rafthttp/http.go
+++ b/server/etcdserver/api/rafthttp/http.go
@@ -497,7 +497,7 @@ func checkClusterCompatibilityFromHeader(lg *zap.Logger, localID types.ID, heade
 		return errIncompatibleVersion
 	}
 	if gcid := header.Get("X-Etcd-Cluster-ID"); gcid != cid.String() {
-		lg.Warn(
+		lg.Fatal(
 			"request cluster ID mismatch",
 			zap.String("local-member-id", localID.String()),
 			zap.String("local-member-cluster-id", cid.String()),

--- a/server/etcdserver/api/rafthttp/http.go
+++ b/server/etcdserver/api/rafthttp/http.go
@@ -497,7 +497,7 @@ func checkClusterCompatibilityFromHeader(lg *zap.Logger, localID types.ID, heade
 		return errIncompatibleVersion
 	}
 	if gcid := header.Get("X-Etcd-Cluster-ID"); gcid != cid.String() {
-		lg.Fatal(
+		lg.Warn(
 			"request cluster ID mismatch",
 			zap.String("local-member-id", localID.String()),
 			zap.String("local-member-cluster-id", cid.String()),

--- a/server/etcdserver/api/rafthttp/pipeline.go
+++ b/server/etcdserver/api/rafthttp/pipeline.go
@@ -165,7 +165,7 @@ func (p *pipeline) post(data []byte) (err error) {
 		p.picker.unreachable(u)
 		// errMemberRemoved is a critical error since a removed member should
 		// always be stopped. So we use reportCriticalError to report it to errorc.
-		if err == errMemberRemoved {
+		if err == errMemberRemoved || err == ErrClusterIDMismatch {
 			reportCriticalError(err, p.errorc)
 		}
 		return err

--- a/server/etcdserver/raft.go
+++ b/server/etcdserver/raft.go
@@ -628,6 +628,7 @@ func restartAsStandaloneNode(cfg config.ServerConfig, snapshot *raftpb.Snapshot,
 	)
 
 	cl := membership.NewCluster(cfg.Logger, membership.WithMaxLearners(cfg.ExperimentalMaxLearners))
+	cid += types.ID(time.Now().UnixMilli())
 	cl.SetID(id, cid)
 	s := raft.NewMemoryStorage()
 	if snapshot != nil {

--- a/server/etcdserver/raft.go
+++ b/server/etcdserver/raft.go
@@ -19,6 +19,7 @@ import (
 	"expvar"
 	"fmt"
 	"log"
+	"math/rand/v2"
 	"sort"
 	"sync"
 	"time"
@@ -578,7 +579,7 @@ func restartAsStandaloneNode(cfg config.ServerConfig, snapshot *raftpb.Snapshot,
 	if snapshot != nil {
 		walsnap.Index, walsnap.Term = snapshot.Metadata.Index, snapshot.Metadata.Term
 	}
-	w, id, cid, st, ents := readWAL(cfg.Logger, cfg.WALDir(), walsnap, cfg.UnsafeNoFsync)
+	w, id, _, st, ents := readWAL(cfg.Logger, cfg.WALDir(), walsnap, cfg.UnsafeNoFsync)
 
 	// discard the previously uncommitted entries
 	for i, ent := range ents {
@@ -604,8 +605,12 @@ func restartAsStandaloneNode(cfg config.ServerConfig, snapshot *raftpb.Snapshot,
 	)
 	ents = append(ents, toAppEnts...)
 
+	cl := membership.NewCluster(cfg.Logger, membership.WithMaxLearners(cfg.ExperimentalMaxLearners))
+	cid := types.ID(rand.Uint64())
+	cl.SetID(id, cid)
+
 	// force commit newly appended entries
-	err := w.Save(raftpb.HardState{}, toAppEnts)
+	err := w.SaveWithMetadata(raftpb.HardState{}, toAppEnts, &pb.Metadata{NodeID: uint64(id), ClusterID: uint64(cid)})
 	if err != nil {
 		cfg.Logger.Fatal("failed to save hard state and entries", zap.Error(err))
 	}
@@ -627,9 +632,6 @@ func restartAsStandaloneNode(cfg config.ServerConfig, snapshot *raftpb.Snapshot,
 		zap.Uint64("commit-index", st.Commit),
 	)
 
-	cl := membership.NewCluster(cfg.Logger, membership.WithMaxLearners(cfg.ExperimentalMaxLearners))
-	cid += types.ID(time.Now().UnixMilli())
-	cl.SetID(id, cid)
 	s := raft.NewMemoryStorage()
 	if snapshot != nil {
 		s.ApplySnapshot(*snapshot)

--- a/server/wal/wal.go
+++ b/server/wal/wal.go
@@ -26,6 +26,8 @@ import (
 	"sync"
 	"time"
 
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 	"go.etcd.io/etcd/pkg/v3/pbutil"
 	"go.etcd.io/etcd/raft/v3"
@@ -912,7 +914,20 @@ func (w *WAL) saveState(s *raftpb.HardState) error {
 	return w.encoder.encode(rec)
 }
 
+func (w *WAL) SaveMetadata(metadata *etcdserverpb.Metadata) error {
+	b := pbutil.MustMarshal(metadata)
+	rec := &walpb.Record{Type: metadataType, Data: b}
+	if err := w.encoder.encode(rec); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (w *WAL) Save(st raftpb.HardState, ents []raftpb.Entry) error {
+	return w.SaveWithMetadata(st, ents, nil)
+}
+
+func (w *WAL) SaveWithMetadata(st raftpb.HardState, ents []raftpb.Entry, metadata *etcdserverpb.Metadata) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -929,6 +944,15 @@ func (w *WAL) Save(st raftpb.HardState, ents []raftpb.Entry) error {
 			return err
 		}
 	}
+
+	if metadata != nil {
+		b := pbutil.MustMarshal(metadata)
+		rec := &walpb.Record{Type: metadataType, Data: b}
+		if err := w.encoder.encode(rec); err != nil {
+			return err
+		}
+	}
+
 	if err := w.saveState(&st); err != nil {
 		return err
 	}

--- a/server/wal/wal.go
+++ b/server/wal/wal.go
@@ -932,7 +932,7 @@ func (w *WAL) SaveWithMetadata(st raftpb.HardState, ents []raftpb.Entry, metadat
 	defer w.mu.Unlock()
 
 	// short cut, do not call sync
-	if raft.IsEmptyHardState(st) && len(ents) == 0 {
+	if metadata == nil && raft.IsEmptyHardState(st) && len(ents) == 0 {
 		return nil
 	}
 
@@ -946,9 +946,7 @@ func (w *WAL) SaveWithMetadata(st raftpb.HardState, ents []raftpb.Entry, metadat
 	}
 
 	if metadata != nil {
-		b := pbutil.MustMarshal(metadata)
-		rec := &walpb.Record{Type: metadataType, Data: b}
-		if err := w.encoder.encode(rec); err != nil {
+		if err := w.SaveMetadata(metadata); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Ensures that the cluster id is different for each invocation of --force-new-cluster