### PR TITLE
OCPBUGS-60874: Revert "OCPBUGS-52181: Ensure cluster id changes during force-new-cluster"

### DIFF
--- a/server/etcdserver/api/rafthttp/pipeline.go
+++ b/server/etcdserver/api/rafthttp/pipeline.go
@@ -165,7 +165,7 @@ func (p *pipeline) post(data []byte) (err error) {
 		p.picker.unreachable(u)
 		// errMemberRemoved is a critical error since a removed member should
 		// always be stopped. So we use reportCriticalError to report it to errorc.
-		if err == errMemberRemoved || err == ErrClusterIDMismatch {
+		if err == errMemberRemoved {
 			reportCriticalError(err, p.errorc)
 		}
 		return err

--- a/server/etcdserver/raft.go
+++ b/server/etcdserver/raft.go
@@ -19,7 +19,6 @@ import (
 	"expvar"
 	"fmt"
 	"log"
-	"math/rand/v2"
 	"sort"
 	"sync"
 	"time"
@@ -579,7 +578,7 @@ func restartAsStandaloneNode(cfg config.ServerConfig, snapshot *raftpb.Snapshot,
 	if snapshot != nil {
 		walsnap.Index, walsnap.Term = snapshot.Metadata.Index, snapshot.Metadata.Term
 	}
-	w, id, _, st, ents := readWAL(cfg.Logger, cfg.WALDir(), walsnap, cfg.UnsafeNoFsync)
+	w, id, cid, st, ents := readWAL(cfg.Logger, cfg.WALDir(), walsnap, cfg.UnsafeNoFsync)
 
 	// discard the previously uncommitted entries
 	for i, ent := range ents {
@@ -605,12 +604,8 @@ func restartAsStandaloneNode(cfg config.ServerConfig, snapshot *raftpb.Snapshot,
 	)
 	ents = append(ents, toAppEnts...)
 
-	cl := membership.NewCluster(cfg.Logger, membership.WithMaxLearners(cfg.ExperimentalMaxLearners))
-	cid := types.ID(rand.Uint64())
-	cl.SetID(id, cid)
-
 	// force commit newly appended entries
-	err := w.SaveWithMetadata(raftpb.HardState{}, toAppEnts, &pb.Metadata{NodeID: uint64(id), ClusterID: uint64(cid)})
+	err := w.Save(raftpb.HardState{}, toAppEnts)
 	if err != nil {
 		cfg.Logger.Fatal("failed to save hard state and entries", zap.Error(err))
 	}
@@ -632,6 +627,8 @@ func restartAsStandaloneNode(cfg config.ServerConfig, snapshot *raftpb.Snapshot,
 		zap.Uint64("commit-index", st.Commit),
 	)
 
+	cl := membership.NewCluster(cfg.Logger, membership.WithMaxLearners(cfg.ExperimentalMaxLearners))
+	cl.SetID(id, cid)
 	s := raft.NewMemoryStorage()
 	if snapshot != nil {
 		s.ApplySnapshot(*snapshot)

--- a/server/wal/wal.go
+++ b/server/wal/wal.go
@@ -27,8 +27,6 @@ import (
 	"sync"
 	"time"
 
-	"go.etcd.io/etcd/api/v3/etcdserverpb"
-
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 	"go.etcd.io/etcd/pkg/v3/pbutil"
 	"go.etcd.io/etcd/raft/v3"
@@ -44,7 +42,6 @@ const (
 	stateType
 	crcType
 	snapshotType
-	metadataModType
 
 	// warnSyncDuration is the amount of time allotted to an fsync before
 	// logging a warning
@@ -65,7 +62,6 @@ var (
 	ErrSnapshotNotFound = errors.New("wal: snapshot not found")
 	ErrSliceOutOfRange  = errors.New("wal: slice bounds out of range")
 	ErrDecoderNotFound  = errors.New("wal: decoder not found")
-	ErrNoMetadata       = errors.New("wal: no metadata found")
 	crcTable            = crc32.MakeTable(crc32.Castagnoli)
 )
 
@@ -474,18 +470,6 @@ func (w *WAL) ReadAll() (metadata []byte, state raftpb.HardState, ents []raftpb.
 				return nil, state, nil, ErrMetadataConflict
 			}
 			metadata = rec.Data
-
-		case metadataModType:
-			if metadata == nil {
-				state.Reset()
-				return nil, state, nil, ErrNoMetadata
-			}
-
-			var meta, metaMod etcdserverpb.Metadata
-			pbutil.MustUnmarshal(&meta, metadata)
-			pbutil.MustUnmarshal(&metaMod, rec.Data)
-			meta.ClusterID = metaMod.ClusterID
-			metadata = pbutil.MustMarshal(&meta)
 
 		case crcType:
 			crc := decoder.crc.Sum32()
@@ -945,25 +929,12 @@ func (w *WAL) saveState(s *raftpb.HardState) error {
 	return w.encoder.encode(rec)
 }
 
-func (w *WAL) SaveMetadata(metadata *etcdserverpb.Metadata) error {
-	b := pbutil.MustMarshal(metadata)
-	rec := &walpb.Record{Type: metadataModType, Data: b}
-	if err := w.encoder.encode(rec); err != nil {
-		return err
-	}
-	return nil
-}
-
 func (w *WAL) Save(st raftpb.HardState, ents []raftpb.Entry) error {
-	return w.SaveWithMetadata(st, ents, nil)
-}
-
-func (w *WAL) SaveWithMetadata(st raftpb.HardState, ents []raftpb.Entry, metadata *etcdserverpb.Metadata) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
 	// short cut, do not call sync
-	if metadata == nil && raft.IsEmptyHardState(st) && len(ents) == 0 {
+	if raft.IsEmptyHardState(st) && len(ents) == 0 {
 		return nil
 	}
 
@@ -975,13 +946,6 @@ func (w *WAL) SaveWithMetadata(st raftpb.HardState, ents []raftpb.Entry, metadat
 			return err
 		}
 	}
-
-	if metadata != nil {
-		if err := w.SaveMetadata(metadata); err != nil {
-			return err
-		}
-	}
-
 	if err := w.saveState(&st); err != nil {
 		return err
 	}


### PR DESCRIPTION
Reverts the cluster id changes again.