### PR TITLE
DO NOT MERGE: OCPBUGS-103516: Toggle madvise around compaction (perfscale)

### DIFF
--- a/etcdutl/go.mod
+++ b/etcdutl/go.mod
@@ -95,4 +95,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace go.etcd.io/bbolt => github.com/openshift/bbolt v0.0.0-20260806041816-148dcef86a15
+replace go.etcd.io/bbolt => github.com/hasbro17/bbolt v0.0.0-20260817210116-ce271e770d58

--- a/etcdutl/go.sum
+++ b/etcdutl/go.sum
@@ -43,6 +43,8 @@ github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0 h1:pRhl55Yx1eC7BZ1N+BBWwn
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0/go.mod h1:XKMd7iuf/RGPSMJ/U4HP0zS2Z9Fh8Ps9a+6X26m/tmI=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 h1:5ZPtiqj0JL5oKWmcsq4VMaAW5ukBEgSGXEN89zeH1Jo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3/go.mod h1:ndYquD05frm2vACXE1nsccT4oJzjhw2arTS2cpUD1PI=
+github.com/hasbro17/bbolt v0.0.0-20260817210116-ce271e770d58 h1:VWYfk5jGeYCNrp6atOe4lXXWc4pRKRWIA1f/8I9sPxc=
+github.com/hasbro17/bbolt v0.0.0-20260817210116-ce271e770d58/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=

--- a/go.mod
+++ b/go.mod
@@ -102,4 +102,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace go.etcd.io/bbolt => github.com/openshift/bbolt v0.0.0-20260806041816-148dcef86a15
+replace go.etcd.io/bbolt => github.com/hasbro17/bbolt v0.0.0-20260817210116-ce271e770d58

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0 h1:pRhl55Yx1eC7BZ1N+BBWwn
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0/go.mod h1:XKMd7iuf/RGPSMJ/U4HP0zS2Z9Fh8Ps9a+6X26m/tmI=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 h1:5ZPtiqj0JL5oKWmcsq4VMaAW5ukBEgSGXEN89zeH1Jo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3/go.mod h1:ndYquD05frm2vACXE1nsccT4oJzjhw2arTS2cpUD1PI=
+github.com/hasbro17/bbolt v0.0.0-20260817210116-ce271e770d58 h1:VWYfk5jGeYCNrp6atOe4lXXWc4pRKRWIA1f/8I9sPxc=
+github.com/hasbro17/bbolt v0.0.0-20260817210116-ce271e770d58/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=

--- a/server/go.mod
+++ b/server/go.mod
@@ -91,4 +91,4 @@ replace go.etcd.io/etcd => ./FORBIDDEN_DEPENDENCY
 
 replace go.etcd.io/tests/v3 => ./FORBIDDEN_DEPENDENCY
 
-replace go.etcd.io/bbolt => github.com/openshift/bbolt v0.0.0-20260806041816-148dcef86a15
+replace go.etcd.io/bbolt => github.com/hasbro17/bbolt v0.0.0-20260817210116-ce271e770d58

--- a/server/go.sum
+++ b/server/go.sum
@@ -65,6 +65,8 @@ github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0 h1:pRhl55Yx1eC7BZ1N+BBWwn
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0/go.mod h1:XKMd7iuf/RGPSMJ/U4HP0zS2Z9Fh8Ps9a+6X26m/tmI=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 h1:5ZPtiqj0JL5oKWmcsq4VMaAW5ukBEgSGXEN89zeH1Jo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3/go.mod h1:ndYquD05frm2vACXE1nsccT4oJzjhw2arTS2cpUD1PI=
+github.com/hasbro17/bbolt v0.0.0-20260817210116-ce271e770d58 h1:VWYfk5jGeYCNrp6atOe4lXXWc4pRKRWIA1f/8I9sPxc=
+github.com/hasbro17/bbolt v0.0.0-20260817210116-ce271e770d58/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=

--- a/server/storage/backend/backend.go
+++ b/server/storage/backend/backend.go
@@ -70,6 +70,10 @@ type Backend interface {
 	OpenReadTxN() int64
 	Defrag() error
 	ForceCommit()
+	// SetMmapAdvice toggles the bbolt mmap madvise hint (Linux only). random=true
+	// restores MADV_RANDOM (steady state); random=false sets MADV_NORMAL, intended
+	// to bracket a compaction pass. See go.etcd.io/bbolt DB.SetMmapAdvice.
+	SetMmapAdvice(random bool) error
 	Close() error
 
 	// SetTxPostLockInsideApplyHook sets a txPostLockInsideApplyHook.
@@ -367,6 +371,14 @@ func (b *backend) ConcurrentReadTx() ReadTx {
 // ForceCommit forces the current batching tx to commit.
 func (b *backend) ForceCommit() {
 	b.batchTx.Commit()
+}
+
+func (b *backend) SetMmapAdvice(random bool) error {
+	// RLock guards against defrag swapping b.db; bbolt serializes the actual
+	// mmap mutation internally via its mmaplock.
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.db.SetMmapAdvice(random)
 }
 
 func (b *backend) Snapshot() Snapshot {

--- a/server/storage/mvcc/kvstore_compaction.go
+++ b/server/storage/mvcc/kvstore_compaction.go
@@ -36,6 +36,14 @@ func (s *store) scheduleCompaction(compactMainRev, prevCompactRev int64) (KeyVal
 	defer func() { dbCompactionKeysCounter.Add(float64(keyCompactions)) }()
 	defer func() { dbCompactionLast.Set(float64(time.Now().Unix())) }()
 
+	// Benchmark (OCPBUGS-103516 / bbolt#939): bracket the whole compaction pass
+	// with MADV_NORMAL and restore MADV_RANDOM afterwards. Set once per pass, not
+	// per batch, so the hint stays NORMAL across the batches and inter-batch
+	// sleeps. The defer covers both the normal and stop-signal returns. Errors are
+	// non-fatal (madvise is best-effort; Linux-only).
+	_ = s.b.SetMmapAdvice(false)
+	defer func() { _ = s.b.SetMmapAdvice(true) }()
+
 	end := make([]byte, 8)
 	binary.BigEndian.PutUint64(end, uint64(compactMainRev+1))
 

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -1001,6 +1001,7 @@ func (b *fakeBackend) OpenReadTxN() int64                                       
 func (b *fakeBackend) Snapshot() backend.Snapshot                                 { return nil }
 func (b *fakeBackend) ForceCommit()                                               {}
 func (b *fakeBackend) Defrag() error                                              { return nil }
+func (b *fakeBackend) SetMmapAdvice(bool) error                                   { return nil }
 func (b *fakeBackend) Close() error                                               { return nil }
 func (b *fakeBackend) SetTxPostLockInsideApplyHook(func())                        {}
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -107,4 +107,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace go.etcd.io/bbolt => github.com/openshift/bbolt v0.0.0-20260806041816-148dcef86a15
+replace go.etcd.io/bbolt => github.com/hasbro17/bbolt v0.0.0-20260817210116-ce271e770d58

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -78,6 +78,8 @@ github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0 h1:pRhl55Yx1eC7BZ1N+BBWwn
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0/go.mod h1:XKMd7iuf/RGPSMJ/U4HP0zS2Z9Fh8Ps9a+6X26m/tmI=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 h1:5ZPtiqj0JL5oKWmcsq4VMaAW5ukBEgSGXEN89zeH1Jo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3/go.mod h1:ndYquD05frm2vACXE1nsccT4oJzjhw2arTS2cpUD1PI=
+github.com/hasbro17/bbolt v0.0.0-20260817210116-ce271e770d58 h1:VWYfk5jGeYCNrp6atOe4lXXWc4pRKRWIA1f/8I9sPxc=
+github.com/hasbro17/bbolt v0.0.0-20260817210116-ce271e770d58/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=


### PR DESCRIPTION
**DO NOT MERGE — throwaway perfscale variant.**

Benchmarks an upstream suggestion on etcd-io/bbolt#939 of toggling `MADV_RANDOM` off only *around compaction* instead of removing it entirely.

- Adds `SetMmapAdvice(random bool)` to the backend `Backend` interface, forwarding to bbolt's `DB.SetMmapAdvice`.
- `scheduleCompaction` sets `MADV_NORMAL` for the whole compaction pass and restores `MADV_RANDOM` on exit (covering both the normal and stop-signal returns), so the pass is bracketed once rather than per batch.
- The bbolt `replace` points at a fork based on v1.4.3 (which keeps `MADV_RANDOM` as the steady state) plus the runtime toggle.

This is the 4th variant in the MADV_RANDOM comparison (broken / removal / posix_fadvise / toggle). To be deleted once the comparison is captured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved database compaction behavior by using optimized memory-mapping advice during compaction and restoring normal operation afterward.

* **Bug Fixes**
  * Reduced the risk of database replacement conflicts while compaction is running.
  * Updated the embedded database backend to a newer maintained implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->