### PR TITLE
[release-4.13] OCPBUGS-102375: Bump golang.org/x/net to v0.35.0-sec.3

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -30,3 +30,5 @@ replace (
 	go.etcd.io/etcd/tests/v3 => ./FORBIDDEN_DEPENDENCY
 	go.etcd.io/etcd/v3 => ./FORBIDDEN_DEPENDENCY
 )
+
+replace golang.org/x/net => github.com/openshift-sustaining/net v0.35.0-sec.3

--- a/client/v3/go.mod
+++ b/client/v3/go.mod
@@ -49,3 +49,5 @@ replace (
 	go.etcd.io/etcd/v3 => ./FORBIDDEN_DEPENDENCY
 	go.etcd.io/tests/v3 => ./FORBIDDEN_DEPENDENCY
 )
+
+replace golang.org/x/net => github.com/openshift-sustaining/net v0.35.0-sec.3

--- a/etcdctl/go.mod
+++ b/etcdctl/go.mod
@@ -84,3 +84,5 @@ replace (
 	go.etcd.io/etcd/v3 => ./FORBIDDEN_DEPENDENCY
 	go.etcd.io/tests/v3 => ./FORBIDDEN_DEPENDENCY
 )
+
+replace golang.org/x/net => github.com/openshift-sustaining/net v0.35.0-sec.3

--- a/etcdutl/go.mod
+++ b/etcdutl/go.mod
@@ -76,3 +76,5 @@ require (
 	google.golang.org/grpc v1.59.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 )
+
+replace golang.org/x/net => github.com/openshift-sustaining/net v0.35.0-sec.3

--- a/go.mod
+++ b/go.mod
@@ -94,3 +94,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
+
+replace golang.org/x/net => github.com/openshift-sustaining/net v0.35.0-sec.3

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -35,3 +35,5 @@ replace (
 	go.etcd.io/etcd/tests/v3 => ./FORBIDDEN_DEPENDENCY
 	go.etcd.io/etcd/v3 => ./FORBIDDEN_DEPENDENCY
 )
+
+replace golang.org/x/net => github.com/openshift-sustaining/net v0.35.0-sec.3

--- a/server/go.mod
+++ b/server/go.mod
@@ -93,3 +93,5 @@ replace (
 	go.etcd.io/etcd => ./FORBIDDEN_DEPENDENCY
 	go.etcd.io/tests/v3 => ./FORBIDDEN_DEPENDENCY
 )
+
+replace golang.org/x/net => github.com/openshift-sustaining/net v0.35.0-sec.3

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -93,3 +93,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
+
+replace golang.org/x/net => github.com/openshift-sustaining/net v0.35.0-sec.3


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-102375 — CVE-2026-33814. golang.org/x/net -> v0.35.0-sec.3.